### PR TITLE
Fix missing unix permission: sticky bit

### DIFF
--- a/fuse.go
+++ b/fuse.go
@@ -537,6 +537,9 @@ func fileMode(unixMode uint32) os.FileMode {
 	if unixMode&syscall.S_ISGID != 0 {
 		mode |= os.ModeSetgid
 	}
+	if unixMode&syscall.S_ISVTX != 0 {
+		mode |= os.ModeSticky
+	}
 	return mode
 }
 
@@ -1610,6 +1613,9 @@ func (a *Attr) attr(out *attr, proto Protocol) {
 	}
 	if a.Mode&os.ModeSetgid != 0 {
 		out.Mode |= syscall.S_ISGID
+	}
+	if a.Mode&os.ModeSticky != 0 {
+		out.Mode |= syscall.S_ISVTX
 	}
 	out.Nlink = a.Nlink
 	out.Uid = a.Uid


### PR DESCRIPTION
The unix suid and sgid bits (mode 0400 and 0200, respectively) are currently preserved, but the sticky bit (mode 0100) was being silently dropped.